### PR TITLE
Add runmodes to submission script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ MitoComp is primarily designed to run on HPC clusters using either a SGE or SLUR
 2. A snakemake installation (tested with snakemake 6.0.2; snakemake can be installed through conda using the following commands)
 
 ```
+$ conda install -c conda-forge mamba
 $ mamba create -c conda-forge -c bioconda -n snakemake snakemake
 ```
 ```

--- a/Snakefile
+++ b/Snakefile
@@ -42,3 +42,6 @@ rule all:
 ####                expand("compare/CGview/{id}.{assembler}.{sub}.cgview.done", id=IDS, sub=sub, assembler=Assembler)
 ####                expand("compare/CCT/{id}.CCT.done", id=IDS) 
 		"output/compare/report/report.html"
+rule assembly_only:
+	input:
+		expand("output/assemblies/{assembler}/{id}/{sub}/{assembler}.ok", id=IDS, sub=sub, assembler=Assembler)

--- a/assembly
+++ b/assembly
@@ -9,7 +9,8 @@ usage() {
         echo
         echo "Options:"
         echo "  -t <submission_system> Specify available submission system. Options: sge, slurm, torque, serial (no submission system)."
-        echo "  -c <cluster_config_file> Path to cluster config file in YAML format (mandatory). "
+	echo "  -c <cluster_config_file> Path to cluster config file in YAML format (mandatory). "
+	echo "  -m <runmode> Determine how far the pipeline should run. Options: assembly, all. Default: all"
         echo "  -s <snakemake_args> Additional arguments passed on to the snakemake command (optional)."
         echo "  -i \"<singularity_args>\" Additional arguments passed on to singularity (optional)."
 	echo
@@ -29,6 +30,7 @@ CLUSTER_CONFIg=""
 SETUP=""
 REPORT=""
 DRY=""
+RUNMODE="all"
 NJOBS="10001"
 commit=$(git rev-parse --short HEAD)
 STDSMARGS="--notemp --latency-wait 60"
@@ -63,19 +65,40 @@ if [ $OPTIND -eq 1 ]; then usage; fi
 # make sure these directories exist before submission because they are needed as singularity bind points
 if [[ ! -d .usr_tmp ]]; then mkdir .usr_tmp; fi 
 if [[ ! -d .conda_pkg_tmp ]]; then mkdir .conda_pkg_tmp; fi
-
-if [[ $CLUSTER == "slurm" ]]; then
-          export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
-          mkdir -p .conda_pkg_tmp
-          snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS $SM_ARGS $DRY
-        unset CONDA_PKGS_DIRS
-  elif [[ $CLUSTER == "sge" ]]; then
-        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS $SM_ARGS $DRY
-  elif [[ $CLUSTER == "torque" ]]; then
-        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS $SM_ARGS $DRY
-  elif [[ $CLUSTER == "serial" ]]; then
-    snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" $STDSMARGS $SM_ARGS $DRY
-  else
-          echo "Submission system not recognized"
-          exit 1
-  fi
+if [[ $RUNMODE == "assembly" ]]; then
+	if [[ $CLUSTER == "slurm" ]]; then
+	          export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
+	          mkdir -p .conda_pkg_tmp
+	          snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --until assembly_only --cluster '$(pwd)/bin/immediate_submit/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS $SM_ARGS $DRY
+	        unset CONDA_PKGS_DIRS
+	  elif [[ $CLUSTER == "sge" ]]; then
+	        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --until assembly_only --cluster "$(pwd)/bin/immediate_submit/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS $SM_ARGS $DRY
+	  elif [[ $CLUSTER == "torque" ]]; then
+	        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --until assembly_only --cluster "$(pwd)/bin/immediate_submit/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS $SM_ARGS $DRY
+	  elif [[ $CLUSTER == "serial" ]]; then
+	    snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" $STDSMARGS $SM_ARGS $DRY
+	  else
+	          echo "Submission system not recognized"
+	          exit 1
+	  fi
+elif [[ $RUNMODE == "all" ]]; then
+	if [[ $CLUSTER == "slurm" ]]; then
+	          export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
+	          mkdir -p .conda_pkg_tmp
+	          snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS $SM_ARGS $DRY
+	        unset CONDA_PKGS_DIRS
+	  elif [[ $CLUSTER == "sge" ]]; then
+	        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS $SM_ARGS $DRY
+	  elif [[ $CLUSTER == "torque" ]]; then
+	        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS $SM_ARGS $DRY
+	  elif [[ $CLUSTER == "serial" ]]; then
+	    snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" $STDSMARGS $SM_ARGS $DRY
+	  else
+	          echo "Submission system not recognized"
+	          exit 1
+	  fi
+else
+	echo "Runmode not recognized: "$RUNMODE
+	exit 1
+fi
+echo $RUNMODE


### PR DESCRIPTION
This PR adds:
- Runmodes for the submission script. This can be specified as such: `./assembly -m assembly` or `./assembly -m all` (which is the default).
- Update of the immediate submit script to the latest commit, which fixes some problems with SGE clusters.
- Small addition to README file to include instructions on how to install mamba.